### PR TITLE
Mirror of kubernetes kubernetes PR IssueNumber 97261

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1158,6 +1158,17 @@ func (proxier *Proxier) syncProxyRules() {
 			}
 		}
 
+		// Capture healthCheckNodePorts
+		if hcNodePort, exists := serviceUpdateResult.HCServiceNodePorts[svcName.NamespacedName]; exists {
+			writeLine(proxier.filterRules,
+				"-A", string(kubeServicesChain),
+				"-m", "comment", "--comment", fmt.Sprintf(`"%s healthCheckNodePort"`, svcNameString),
+				"-m", protocol, "-p", protocol,
+				"--dport", strconv.Itoa(int(hcNodePort)),
+				"-j", "ACCEPT",
+			)
+		}
+
 		// Capture load-balancer ingress.
 		fwChain := svcInfo.serviceFirewallChainName
 		for _, ingress := range svcInfo.LoadBalancerIPStrings() {


### PR DESCRIPTION
Mirror of kubernetes kubernetes PR IssueNumber 97261
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds iptable ACCEPT rule for service.spec.healthCheckNodePort if there is any.  Currently the accessibility of `spec.healthCheckNodePort` depends on the default policy in iptables.


**Which issue(s) this PR fixes**:
Fixes 97225 

**Special notes for your reviewer**:
This PR only covers change for iptables.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A
