### PR TITLE
Mirror of kubernetes kubernetes PR IssueNumber 97255

### DIFF
--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -127,7 +127,7 @@ func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (
 				// We have no means of passing the additional information down using
 				// watch API based on watch.Event but the caller can filter such
 				// objects by checking if metadata.deletionTimestamp is set
-				obj = staleObj
+				obj = staleObj.Obj
 			}
 
 			e.push(watch.Event{


### PR DESCRIPTION
Mirror of kubernetes kubernetes PR IssueNumber 97255
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.mdyour-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.mddevelopment-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.mdissuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.mdbest-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.mdmarking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**What this PR does / why we need it**:
This PR fixes a panic when the deleted object is stale. `cache.DeletedFinalStateUnknown` does not implement `runtime.Object` and can cause a panic at https://github.com/kubernetes/kubernetes/blob/0e2bf1e49f704b6d5f56d2c7ec8e10cfb2545bb6/staging/src/k8s.io/client-go/tools/watch/informerwatcher.goL135
In such case, I believe it is supposed to get `runtime.Obj` from the `Obj` field of `cache.DeletedFinalStateUnknown` instead, similar to other usages https://github.com/kubernetes/kubernetes/search?q=%22DeletedFinalStateUnknown%22+%22.Obj%22.

Unfortunately, I don't know how to add a test for this, but we patched our `k8s.io/client-go` with this change in February and the panic below has gone away since.
```
E0211 23:10:08.521653       1 runtime.go:73] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(nil), concrete:(*runtime._type)(0x3c75500), asserted:(*runtime._type)(0x3ae5a80), missingMethod:"DeepCopyObject"} (interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject)
goroutine 73 [running]:
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x3aad640, 0xc000c3a3f0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:69 +0x7b
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51 +0x82
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x105
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func3(0x3c75500, 0xc000c059a0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:135 +0x9d
<redacted>/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:209
<redacted>/vendor/k8s.io/client-go/tools/cache.newInformer.func1(0x3ac89a0, 0xc000e36ec0, 0x1, 0xc000e36ec0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:373 +0x37f
<redacted>/vendor/k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc0003f91e0, 0xc000bfdf80, 0x0, 0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:422 +0x209
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000ef9680)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:150 +0x40
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000031f70)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x54
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00061df70, 0x3b9aca00, 0x0, 0xc0009a8701, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).Run(0xc000ef9680, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:124 +0x2a8
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func4(0xc000c179e0, 0xc000bfde60, 0x4bf21e0, 0xc000ef9680, 0xc000d12cc0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:146 +0x90
created by <redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:143 +0x3b0
panic: interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject [recovered]
	panic: interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject [recovered]
	panic: interface conversion: cache.DeletedFinalStateUnknown is not runtime.Object: missing method DeepCopyObject

goroutine 73 [running]:
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x105
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x105
panic(0x3aad640, 0xc000c3a3f0)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func3(0x3c75500, 0xc000c059a0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:135 +0x9d
<redacted>/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:209
<redacted>/vendor/k8s.io/client-go/tools/cache.newInformer.func1(0x3ac89a0, 0xc000e36ec0, 0x1, 0xc000e36ec0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:373 +0x37f
<redacted>/vendor/k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc0003f91e0, 0xc000bfdf80, 0x0, 0x0, 0x0, 0x0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:422 +0x209
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).processLoop(0xc000ef9680)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:150 +0x40
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000031f70)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x54
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00061df70, 0x3b9aca00, 0x0, 0xc0009a8701, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/<redacted>/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
<redacted>/vendor/k8s.io/client-go/tools/cache.(*controller).Run(0xc000ef9680, 0xc000c17920)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/cache/controller.go:124 +0x2a8
<redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher.func4(0xc000c179e0, 0xc000bfde60, 0x4bf21e0, 0xc000ef9680, 0xc000d12cc0)
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:146 +0x90
created by <redacted>/vendor/k8s.io/client-go/tools/watch.NewIndexerInformerWatcher
	/go/src/<redacted>/vendor/k8s.io/client-go/tools/watch/informerwatcher.go:143 +0x3b0
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes <issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes 

**Special notes for your reviewer**:
I'm open to write a test for this fix if someone can point me to the right direction.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

